### PR TITLE
add Jenkinsfile for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+//Jenkins pipelines are stored in shared libaries. Please see: https://github.com/NREL/cbci_jenkins_libs 
+
+
+@Library('cbci_shared_libs@develop') _
+
+openstudio_measures()    


### PR DESCRIPTION
Adding Jenkinsfile for CI pipeline. 

This is the same CI pipeline script as used by https://github.com/NREL/OpenStudio-measures

This is the Jenkins Pipeline that will be ran on any PR to develop or master branch. 
https://github.com/NREL/cbci_jenkins_libs/blob/develop/vars/openstudio_measures.groovy

